### PR TITLE
Defer initial GitHub redelivery scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Relative `tracking` paths resolve from the YAML file location. The config loader
 
 ## Optional Redelivery Polling
 
-`gh.redelivery` is provider-owned and defaults to `false`. When enabled, the service polls recent GitHub App webhook deliveries, retries unresolved failed delivery GUIDs once per GUID, and caps each scan at `maxPerRun` redelivery requests. On GitHub.com, only deliveries from the last 3 days are eligible for redelivery.
+`gh.redelivery` is provider-owned and defaults to `false`. When enabled, the service polls recent GitHub App webhook deliveries, retries unresolved failed delivery GUIDs once per GUID, and caps each scan at `maxPerRun` redelivery requests. The first automatic scan starts after `intervalSeconds` elapses, not immediately at process boot. On GitHub.com, only deliveries from the last 3 days are eligible for redelivery.
 
 ```yaml
 gh:

--- a/docs/design-docs/workflow-config.md
+++ b/docs/design-docs/workflow-config.md
@@ -156,4 +156,4 @@ workflow:
 
 - The service starts with `npm start -- --config /path/to/service.yml`.
 - The shipped GitHub provider validates `gh.*` and requires `GITHUB_WEBHOOK_SECRET` plus `GITHUB_APP_PRIVATE_KEY_PATH` during startup.
-- When `gh.redelivery` is enabled, `main.ts` starts a second GitHub App polling loop that scans the last 3 days of app webhook deliveries, retries unresolved failures once per delivery GUID, and persists its checkpoint beside the tracked run artifacts.
+- When `gh.redelivery` is enabled, `main.ts` starts a second GitHub App polling loop that waits one configured interval before its first scan, then scans the last 3 days of app webhook deliveries, retries unresolved failures once per delivery GUID, and persists its checkpoint beside the tracked run artifacts.

--- a/src/app/providers/github-redelivery-worker.ts
+++ b/src/app/providers/github-redelivery-worker.ts
@@ -102,8 +102,6 @@ export function createGitHubRedeliveryWorker(options: GitHubRedeliveryWorkerOpti
       }
 
       started = true;
-      void this.runOnce().catch((error) => logWorkerError(log, error));
-
       timer = setInterval(() => {
         if (stopped) {
           return;

--- a/tests/app/github-redelivery-worker.test.ts
+++ b/tests/app/github-redelivery-worker.test.ts
@@ -188,6 +188,65 @@ test("createGitHubRedeliveryWorker persists settled GUIDs across restarts", asyn
   assert.deepEqual(harness.redeliveryCalls, [11]);
 });
 
+test("createGitHubRedeliveryWorker start waits until the first interval before scanning", async (t) => {
+  const dir = await mkdtemp(path.join(tmpdir(), "gao-gh-redelivery-start-"));
+  const env = await createGitHubAppEnv(dir);
+  const config = createServiceConfig();
+  const trackingDir = path.join(dir, "tracking");
+  let listCalls = 0;
+
+  config.tracking = {
+    stateFile: path.join(trackingDir, "state.json"),
+    logFile: path.join(trackingDir, "runs.jsonl")
+  };
+  if (!config.gh) {
+    throw new Error("Missing test GitHub config.");
+  }
+  config.gh = {
+    ...config.gh,
+    redelivery: {
+      intervalSeconds: 1,
+      maxPerRun: 5
+    }
+  };
+
+  t.after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const worker = createGitHubRedeliveryWorker({
+    github: resolveGitHubProviderConfig(config.gh),
+    tracking: config.tracking,
+    env: {
+      ...process.env,
+      GITHUB_APP_PRIVATE_KEY_PATH: env.pemPath
+    },
+    logSink: createNoOpLogSink(),
+    client: {
+      async listDeliveries() {
+        listCalls += 1;
+        return {
+          deliveries: [],
+          nextPageUrl: undefined
+        };
+      },
+      async getDelivery() {
+        throw new Error("should not be called");
+      },
+      async redeliverDelivery() {}
+    }
+  });
+
+  worker.start();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(listCalls, 0);
+
+  await new Promise((resolve) => setTimeout(resolve, 1100));
+  assert.equal(listCalls, 1);
+
+  await worker.stop();
+});
+
 function createIssueOpenedDetail(): GitHubAppWebhookDeliveryDetail {
   return {
     ...createDeliverySummary(11, "guid-retry"),
@@ -423,11 +482,15 @@ test("createGitHubRedeliveryWorker stop waits for an in-flight scan and cancels 
           nextPageUrl: undefined
         };
       },
+      async getDelivery() {
+        throw new Error("should not be called");
+      },
       async redeliverDelivery() {}
     }
   });
 
   worker.start();
+  await new Promise((resolve) => setTimeout(resolve, 1100));
   await started.promise;
 
   let stopResolved = false;

--- a/tests/service/orchestration/process-trigger-submission.test.ts
+++ b/tests/service/orchestration/process-trigger-submission.test.ts
@@ -215,7 +215,10 @@ test("processTriggerSubmission prepares an executor-specific workspace before la
       async markTerminal() {
         throw new Error("should not be called");
       },
-      async reconcileActiveRuns() {}
+      async reconcileActiveRuns() {},
+      async getActiveRunCount() {
+        return 0;
+      }
     },
     logSink: createNoOpLogSink()
   });


### PR DESCRIPTION
## Summary
- defer the first automatic GitHub redelivery scan until the configured interval elapses
- add regression coverage for deferred startup scanning and updated shutdown timing
- document the delayed first scan behavior for operators

## Testing
- `npm run check`

## Linked Issue
- none